### PR TITLE
验证了离线文件和离线消息功能；改进了消息输出

### DIFF
--- a/server/config.ini
+++ b/server/config.ini
@@ -17,5 +17,5 @@ socket_timeout = 5
 file_transfer_interval = 0.5
 
 [Logger]
-is_json_format = False
+is_json_format = True
 log_file = server.log

--- a/server/config.ini
+++ b/server/config.ini
@@ -15,3 +15,7 @@ heartbeat_timeout = 30
 default_chunk_size = 1024
 socket_timeout = 5
 file_transfer_interval = 0.5
+
+[Logger]
+is_json_format = False
+log_file = server.log

--- a/server/server.py
+++ b/server/server.py
@@ -53,10 +53,10 @@ class MessageServer:
                 message_json = client_socket.recv(1024).decode('utf-8')
                 message = json.loads(message_json)
                 formatted_json = json.dumps(message, indent=2)
-                if is_json_format:
-                    logging.debug(f"Received message: {formatted_json}")
+                if is_json_format == 'True':
+                    logging.debug(f"[Received Message]: {formatted_json}")
                 else:
-                    logging.debug(f"Received message: {message}")
+                    logging.debug(f"[Received Message]: {message_json}")
                 last_heartbeat_time = datetime.now()
                 type = message['type']
                 if type == 'heartbeat':
@@ -97,10 +97,10 @@ class MessageServer:
         is_json_format = config.is_json_format
         message_json = json.dumps(message)
         formatted_json = json.dumps(message, indent=2)
-        if is_json_format:
-            logging.debug(f"Send message: {formatted_json}")
+        if is_json_format == 'True':
+            logging.debug(f"[Send Message]: {formatted_json}")
         else:
-            logging.debug(f"Send message: {message}")
+            logging.debug(f"[Send Message]: {message_json}")
         return client_socket.send(message_json.encode('utf-8'))
 
     def start(self):
@@ -108,7 +108,6 @@ class MessageServer:
         server_socket.bind((self.host, self.port))
         server_socket.listen(5)
         logging.info(f"Server started on {self.host}:{self.port}")
-
         while True:
             client_socket, client_address = server_socket.accept()
             logging.info(f"Client connected from {client_address[0]}:{client_address[1]}")

--- a/server/server.py
+++ b/server/server.py
@@ -165,6 +165,7 @@ class MessageHandler:
                     self.manager_instance.message_server.send_message(client_socket, message)
                     time.sleep(0.3)
                     self.file_transfer_server.send_file(file_path, request_data['chunk_size'])
+                time.sleep(0.3)
 
     def handle_login(self, request_data, request_timestamp, client_socket):
         username = request_data.get('username')

--- a/server/server.py
+++ b/server/server.py
@@ -48,9 +48,15 @@ class MessageServer:
         username = None
         while True:
             try:
+                config = Config()
+                is_json_format = config.is_json_format
                 message_json = client_socket.recv(1024).decode('utf-8')
-                logging.debug("server receive message:" + message_json)
                 message = json.loads(message_json)
+                formatted_json = json.dumps(message, indent=2)
+                if is_json_format:
+                    logging.debug(f"Received message: {formatted_json}")
+                else:
+                    logging.debug(f"Received message: {message}")
                 last_heartbeat_time = datetime.now()
                 type = message['type']
                 if type == 'heartbeat':
@@ -87,8 +93,14 @@ class MessageServer:
     def send_message(client_socket, message):
         if message is None:
             return
+        config = Config()
+        is_json_format = config.is_json_format
         message_json = json.dumps(message)
-        logging.debug("Send message:" + message_json)
+        formatted_json = json.dumps(message, indent=2)
+        if is_json_format:
+            logging.debug(f"Send message: {formatted_json}")
+        else:
+            logging.debug(f"Send message: {message}")
         return client_socket.send(message_json.encode('utf-8'))
 
     def start(self):
@@ -149,15 +161,11 @@ class MessageHandler:
                     MessageServer.send_message(client_socket, personal_message)
                 elif type == 'file':
                     request_data = message['data']
-                    file_path = request_data['file_path']
+                    file_path = message['file_path']
                     message = message = mb.build_send_file_request(request_data['sender'], request_data['receiver'], request_data['file_name'], request_data['file_size'], request_data['timestamp'], request_data['chunk_size'])
                     self.manager_instance.message_server.send_message(client_socket, message)
                     time.sleep(0.3)
-                    success = self.file_transfer_server.send_file(file_path, request_data['chunk_size'])
-                    if success:
-                        response_text = 'File transfer success'
-                    else:
-                        response_text = 'File transfer failed'
+                    self.file_transfer_server.send_file(file_path, request_data['chunk_size'])
 
     def handle_login(self, request_data, request_timestamp, client_socket):
         username = request_data.get('username')
@@ -165,7 +173,7 @@ class MessageHandler:
         success, response_text = self.user_manager.login_user(username, password)
         if success:
             self.user_manager.set_online(username, client_socket)
-        logging.debug(self.user_manager.is_online(username))
+        self.send_offline_messages(username, client_socket)
         return mb.build_response(success, response_text, request_timestamp)
 
     def handle_logout(self, message):
@@ -313,22 +321,45 @@ class Config:
         self.heartbeat_timeout = int(self.config['Server']['heartbeat_timeout'])
         self.socket_timeout = int(self.config['Server']['socket_timeout'])
         self.file_transfer_interval = float(self.config['Server']['file_transfer_interval'])
+        self.is_json_format = self.config['Logger']['is_json_format']
+        self.log_file = self.config['Logger']['log_file']
 
-def config_logging(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'):
+class ColoredFormatter(logging.Formatter):
+    COLORS = {
+        'DEBUG': '\033[92m',  # 绿色
+        'INFO': '\033[94m',   # 蓝色
+        'WARNING': '\033[93m',  # 黄色
+        'ERROR': '\033[91m',  # 红色
+        'CRITICAL': '\033[91m'  # 红色
+    }
+    RESET = '\033[0m'
+
+    def format(self, record):
+        loglevel_color = self.COLORS.get(record.levelname, self.RESET)
+        log_msg = super(ColoredFormatter, self).format(record)
+        log_msg = log_msg.replace('$LOG_COLOR', loglevel_color)
+        log_msg = log_msg.replace('$RESET', self.RESET)
+        return log_msg
+
+def config_logging(level=logging.DEBUG, format='%(asctime)s - $LOG_COLOR%(levelname)s$RESET - %(message)s'):
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
 
     if not logger.handlers:
         console_handler = logging.StreamHandler()
         console_handler.setLevel(logging.DEBUG)
-        formatter = logging.Formatter(format)
+
+        formatter = ColoredFormatter(format)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
-        file_handler = logging.FileHandler('server.log')
+        config = Config()
+        log_file = config.log_file
+        file_handler = logging.FileHandler(log_file)
         file_handler.setLevel(logging.INFO)
-        file_handler.setFormatter(formatter)
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
         logger.addHandler(file_handler)
+
 
 if __name__ == '__main__':
     config_logging()

--- a/server/user_manager.py
+++ b/server/user_manager.py
@@ -114,7 +114,6 @@ class UserManager:
     
     def remove_friend(self, username, friend_username):
         is_exists = self.is_username_exist(username)
-        logging.debug(f'[ATTENTION]friend_username: {friend_username}, is_exists: {is_exists}')
         if not is_exists:
             return False, 'User is not exist'
         self.cursor.execute('DELETE FROM friendship WHERE username = ? AND friendname = ?', (username, friend_username))

--- a/tool/client_no_ui.py
+++ b/tool/client_no_ui.py
@@ -161,6 +161,7 @@ class ChatConnection:
         else: response = {'success':False, 'message': 'Can not send to yourself'}
         self.parent.show_response(response)
     def show_response(self, response):
+        if not response: return False
         success = 'sccess' if response['success']  else 'failure'
         print(f"[Response]{success}: {response['message']}")
         return response['success']
@@ -173,35 +174,6 @@ class ChatConnection:
         time.sleep(0.3)
         if file_transfer_client.send_file(file_path):
             print(f"File {file_name} sent successfully.")
-
-def debug_login_as(connection, username):
-    password = '123'
-    message = mb.build_register_request(username, password)
-    connection.send_message(message)
-    time.sleep(0.3)
-    response = connection.get_response(message['timestamp'])
-    connection.show_response(response)
-    message = mb.build_login_request(username, password)
-    connection.send_message(message)
-    time.sleep(0.3)
-    response = connection.get_response(message['timestamp'])
-    connection.show_response(response)
-    CurrentUser.set_username(username)
-
-def debug_add_friend(connection, friend):
-    username = CurrentUser.get_username()
-    message = mb.build_add_friend_request(username, friend)
-    connection.send_message(message)
-    response = connection.get_response(message['timestamp'])
-    connection.show_response(response)
-
-def debug_get_friends():
-    username = CurrentUser.get_username()
-    message = mb.build_get_friends_request(username)
-    connection.send_message(message)
-    response = connection.get_response(message['timestamp'])
-    connection.show_response(response)
-    print(response['data'])
 
 class FileTransferClient:
 
@@ -234,9 +206,38 @@ class FileTransferClient:
         print(f"File {file_path} received successfully.")
         return True
 
+def debug_login_as(connection, username):
+    password = '123'
+    message = mb.build_register_request(username, password)
+    connection.send_message(message)
+    time.sleep(0.3)
+    response = connection.get_response(message['timestamp'])
+    connection.show_response(response)
+    message = mb.build_login_request(username, password)
+    connection.send_message(message)
+    time.sleep(0.3)
+    response = connection.get_response(message['timestamp'])
+    connection.show_response(response)
+    CurrentUser.set_username(username)
+
+def debug_add_friend(connection, friend):
+    username = CurrentUser.get_username()
+    message = mb.build_add_friend_request(username, friend)
+    connection.send_message(message)
+    response = connection.get_response(message['timestamp'])
+    connection.show_response(response)
+
+def debug_get_friends():
+    username = CurrentUser.get_username()
+    message = mb.build_get_friends_request(username)
+    connection.send_message(message)
+    response = connection.get_response(message['timestamp'])
+    connection.show_response(response)
+    print(response['data'])
+
 def debug_send_file(reciver):
     username = CurrentUser.get_username()
-    file_path = './wdc_debug/large_file.bin'
+    file_path = 'large_file.bin'
     # file_path = './wdc_debug/test.txt'
     connection.send_file(username, reciver, file_path)
 
@@ -246,19 +247,23 @@ def debug_remove_friend(connection, friend):
     connection.send_message(message)
     response = connection.get_response(message['timestamp'])
     connection.show_response(response)
+    
+def debug_send_message(connection, username, message):
+    message = mb.build_send_personal_message_request(CurrentUser.get_username(), username, message)
+    connection.send_message(message)
+    response = connection.get_response(message['timestamp'])
+    connection.show_response(response)
 
 if __name__ == '__main__':
     ip_address = '127.0.0.1'
+    if sys.argv[1] == '2':
+        time.sleep(15)
     connection = ChatConnection(ip_address, 9999)
     file_transfer_client = FileTransferClient(ip_address, 9998)
     connection.start_connect()
     username = 'user' + sys.argv[1]
     debug_login_as(connection, username)
     if sys.argv[1] == '1':
-        debug_add_friend(connection, 'user2')
-        time.sleep(0.5)
-        debug_get_friends()
-        time.sleep(0.5)
-        debug_remove_friend(connection, 'user2')
-        time.sleep(0.5)
-        debug_get_friends()
+        time.sleep(1)
+        debug_send_file('user2')
+        debug_send_message(connection, 'user2', 'Hello user2')

--- a/tool/run_client_no_ui.bat
+++ b/tool/run_client_no_ui.bat
@@ -15,7 +15,7 @@ timeout /t 2 >nul
 rem Start the client
 rem start pythonw /chatapp/client.py
 start cmd /k python ./tool/client_no_ui.py 1
-timeout /t 1 >nul
+timeout /t 2 >nul
 start cmd /k python ./tool/client_no_ui.py 2
 
 rem Wait for the user to press any key before closing the window


### PR DESCRIPTION
### 更新说明
#### 实现了离线文件和离线消息功能
当文件或者消息传输完成后对方不在线，则会存入离线消息队列，并在对方上线时进行发送
离线消息保存在内存中, 若服务器关闭, 则离线消息会丢失
![image](https://github.com/Wang-Decheng/ChatApp/assets/54239890/2e1053ed-8843-4f4d-b02b-863f8c59c85e)
#### 增加了json消息的格式化输出
![image](https://github.com/Wang-Decheng/ChatApp/assets/54239890/bbc631d8-d878-48b2-bce8-b151db57b776)
可以通过`config.ini`中的选项改变配置
```
[Logger]
is_json_format = True
```
注: 除True外的其他值均不会使该配置生效
### 接口说明
#### 发送部分
##### 1.发送请求
发送请求格式参照`build_send_file_request`
``` python
def build_send_file_request(sender, receiver, file_name, file_size, timestamp = time.time(), chunk_size = 1024):
        request_data = {
            'sender': sender,
            'receiver': receiver,
            'file_name': file_name,
            'file_size': file_size,
            'chunk_size': chunk_size,
            'timestamp': timestamp
        }
        return MessageBuilder.build_request('file_transfer', request_data)
```
##### 2. sleep
sleep恰当的时间确保服务器开启接受文件的服务
##### 3.发送文件
向服务器文件传输端口发起连接并传输文件，可参照`client_no_ui:FileTransferClient:send_file()`
```
def send_file(self, file_path, chunk_size = 1024):
        client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
        client_socket.connect((self.host, self.port))
        with open(file_path, 'rb') as f:
            while True:
                data = f.read(chunk_size)
                if not data:
                    break
                client_socket.send(data)
        client_socket.close()
        return True
```
#### 接受部分
当接收到服务器发送的传输文件请求时，根据请求中的信息处理文件的保存路径和传递相关信息，然后立即向服务器文件传输端口发起连接并接受文件,  可参照`client_no_ui:FileTransferClient:receive_file()`
``` python
def receive_file(self, file_path, chunk_size = 1024):
        client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
        client_socket.connect((self.host, self.port))
        with open(file_path, 'wb') as f:
            while True:
                data = client_socket.recv(chunk_size)
                if not data:
                    break
                f.write(data)
        client_socket.close()
        print(f"File {file_path} received successfully.")
        return True
```
注：请自行选择合适的保存文件路径
### BUG和可能的改进
#### BUG
- 有几率出现jsonEncodeError(单条,不会崩溃), 或出现连续刷屏的jsonEncodeError(多条,会崩溃)
#### 未测试
- 未测试多条离线消息
- 未测试中文文件名或含有特殊字符的文件名
- 未测试传输中断的情况
#### 可能的改进
- 目前文件传输过程和离线文件、消息传输中缺少对应的消息提示，可考虑加入新的消息类型'info'
- 未加入删除服务器暂存的文件的功能
- 在开启消息的格式化输出后心跳包消息占用大量控制台窗口空间，可考虑增加选项控制是否输出心跳包消息